### PR TITLE
allowing status code and response options for sending 429 rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Probably should be used with/after extras.fixIP so that the users real IP is sen
           holdTime: 10,
           whitelist: {
               '127.0.0.1': true
-          }
+          },
+          errorCode: 403,
+          errorHtml: '<html><title>403 Forbidden</title><body><h1>403 Forbidden</h1><p>Client denied by server configuration.</p></body></html>'
         }));
 
     });

--- a/lib/express-extras.js
+++ b/lib/express-extras.js
@@ -37,7 +37,6 @@ exports.fixIP = function(header) {
     };
 };
 
-var ERROR = '<html><title>403 Forbidden</title><body><h1>403 Forbidden</h1><p>Client denied by server configuration.</p></body></html>';
 
 var hashKey = function(req) {
     return new crypto.Hash('md5').update(req.ip || req.socket.remoteAddress + '::' + req.url + '::' + req.headers['user-agent']).digest('hex');
@@ -52,7 +51,9 @@ var rules = {
     holdTime: 10,
     whitelist: {
         '127.0.0.1': true
-    }
+    },
+    errorCode: 403,
+    errorHtml: '<html><title>403 Forbidden</title><body><h1>403 Forbidden</h1><p>Client denied by server configuration.</p></body></html>'
 };
 
 /**
@@ -72,7 +73,9 @@ var rules = {
 *   holdTime: 10,
 *   whitelist: {
 *       '127.0.0.1': true
-*   }
+*   },
+*   errorCode: 403,
+*   errorHtml: '<html><title>403 Forbidden</title><body><h1>403 Forbidden</h1><p>Client denied by server configuration.</p></body></html>'
 * }));
 */
 exports.throttle = function(o) {
@@ -102,7 +105,7 @@ exports.throttle = function(o) {
         }
         if (onHold[key]) {
             if ((stamp - onHold[key]) <= opts.holdTime) {
-                res.send(ERROR, 403);
+                res.send(opts.errorHtml, opts.errorCode);
                 return;
             } else {
                 delete onHold[key];
@@ -112,7 +115,7 @@ exports.throttle = function(o) {
         if ((stamp - hashList[key].stamp) <= opts.urlSec) {
             if (hashList[key].count >= opts.urlCount) {
                 onHold[key] = stamp;
-                res.send(ERROR, 403);
+                res.send(opts.errorHtml, opts.errorCode);
                 return;
             }
         } else {


### PR DESCRIPTION
I had needed to send a different status code and response than 403, so I made this fork where you can pass `errorCode` and `errorHtml` as options.
